### PR TITLE
Fix import fallback for Mixture of Experts

### DIFF
--- a/Main.py
+++ b/Main.py
@@ -935,8 +935,13 @@ class RobustPCA(BaseEstimator, TransformerMixin):
         return self.fit(X, y).transform(X)
 
 # ═════════════════════════ MIXTURE OF EXPERTS ══════════════════════════════════════════
-from cuml.linear_model import LogisticRegression 
-from cuml import KMeans
+# Prefer GPU-accelerated implementations when available, but fall back to sklearn
+try:
+    from cuml.linear_model import LogisticRegression
+    from cuml import KMeans
+except Exception:  # cuml not available
+    from sklearn.linear_model import LogisticRegression
+    from sklearn.cluster import KMeans
 
 class MixtureOfExpertsRegressor(BaseEstimator, TransformerMixin):
     """Mixture of Experts with gating network for high/low solubility prediction"""


### PR DESCRIPTION
## Summary
- gracefully fall back to sklearn implementations for `LogisticRegression` and `KMeans` if `cuml` is unavailable

## Testing
- `python -m py_compile Main.py`

------
https://chatgpt.com/codex/tasks/task_e_685f91a65d508325abfac126a4911e68